### PR TITLE
Change repo URL to GitHub & default branch to rolling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ variables:
   PACKAGES_LIST: tracetools_analysis ros2trace_analysis
   BASE_IMAGE_ID: registry.gitlab.com/ros-tracing/ci_base
   DISTRO: rolling
-  ROS2TRACING_BRANCH: master
+  ROS2TRACING_BRANCH: rolling
 
 stages:
   - build
@@ -78,7 +78,5 @@ trigger_gen_docs:
   stage: report
   only:
     refs:
-      - master
-      - galactic
-      - foxy
+      - rolling
   trigger: ros-tracing/tracetools_analysis-api

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # tracetools_analysis
 
-[![pipeline status](https://gitlab.com/ros-tracing/tracetools_analysis/badges/master/pipeline.svg)](https://gitlab.com/ros-tracing/tracetools_analysis/commits/master)
-[![codecov](https://codecov.io/gl/ros-tracing/tracetools_analysis/branch/master/graph/badge.svg)](https://codecov.io/gl/ros-tracing/tracetools_analysis)
+<!-- [![GitHub CI](https://github.com/ros-tracing/tracetools_analysis/actions/workflows/test.yml/badge.svg?branch=rolling)](https://github.com/ros-tracing/tracetools_analysis/actions/workflows/test.yml) -->
+[![codecov](https://codecov.io/gh/ros-tracing/tracetools_analysis/branch/rolling/graph/badge.svg)](https://codecov.io/gh/ros-tracing/tracetools_analysis)
 
-Analysis tools for [ROS 2 tracing](https://gitlab.com/ros-tracing/ros2_tracing).
+Analysis tools for [`ros2_tracing`](https://github.com/ros2/ros2_tracing).
 
-**Note**: make sure to use the right branch, depending on the ROS 2 distro: [use `master` for Rolling, `galactic` for Galactic, etc.](https://docs.ros.org/en/rolling/Contributing/Developer-Guide.html#branches)
+**Note**: make sure to use the right branch, depending on the ROS 2 distro: [use `rolling` for Rolling, `humble` for Humble, etc.](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Developer-Guide.html)
 
 ## Trace analysis
 
-After generating a trace (see [`ros2_tracing`](https://gitlab.com/ros-tracing/ros2_tracing#tracing)), we can analyze it to extract useful execution data.
+After generating a trace (see [`ros2_tracing`](https://github.com/ros2/ros2_tracing#tracing)), we can analyze it to extract useful execution data.
 
 ### Commands
 
@@ -84,7 +84,7 @@ $ pip3 install bokeh
 
 ## Design
 
-See the [`ros2_tracing` design document](https://gitlab.com/ros-tracing/ros2_tracing/blob/master/doc/design_ros_2.md), especially the [*Goals and requirements*](https://gitlab.com/ros-tracing/ros2_tracing/blob/master/doc/design_ros_2.md#goals-and-requirements) and [*Analysis*](https://gitlab.com/ros-tracing/ros2_tracing/blob/master/doc/design_ros_2.md#analysis) sections.
+See the [`ros2_tracing` design document](https://github.com/ros2/ros2_tracing/blob/master/doc/design_ros_2.md), especially the [*Goals and requirements*](https://github.com/ros2/ros2_tracing/blob/master/doc/design_ros_2.md#goals-and-requirements) and [*Analysis*](https://github.com/ros2/ros2_tracing/blob/master/doc/design_ros_2.md#analysis) sections.
 
 ## Packages
 

--- a/ros2trace_analysis/package.xml
+++ b/ros2trace_analysis/package.xml
@@ -7,8 +7,8 @@
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <license>Apache 2.0</license>
   <url type="website">https://index.ros.org/p/ros2trace_analysis/</url>
-  <url type="repository">https://gitlab.com/ros-tracing/tracetools_analysis</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/tracetools_analysis/-/issues</url>
+  <url type="repository">https://github.com/ros-tracing/tracetools_analysis</url>
+  <url type="bugtracker">https://github.com/ros-tracing/tracetools_analysis/issues</url>
   <author email="christophe.bedard@apex.ai">Christophe Bedard</author>
 
   <depend>ros2cli</depend>

--- a/ros2trace_analysis/setup.py
+++ b/ros2trace_analysis/setup.py
@@ -22,7 +22,7 @@ setup(
     ),
     author='Christophe Bedard',
     author_email='christophe.bedard@apex.ai',
-    url='https://gitlab.com/ros-tracing/tracetools_analysis',
+    url='https://github.com/ros-tracing/tracetools_analysis',
     keywords=[],
     description='The trace-analysis command for ROS 2 command line tools.',
     long_description=(

--- a/tracetools_analysis/package.xml
+++ b/tracetools_analysis/package.xml
@@ -8,8 +8,8 @@
   <maintainer email="ingo.luetkebohle@de.bosch.com">Ingo Lütkebohle</maintainer>
   <license>Apache 2.0</license>
   <url type="website">https://index.ros.org/p/tracetools_analysis/</url>
-  <url type="repository">https://gitlab.com/ros-tracing/tracetools_analysis</url>
-  <url type="bugtracker">https://gitlab.com/ros-tracing/tracetools_analysis/-/issues</url>
+  <url type="repository">https://github.com/ros-tracing/tracetools_analysis</url>
+  <url type="bugtracker">https://github.com/ros-tracing/tracetools_analysis/issues</url>
   <author email="ingo.luetkebohle@de.bosch.com">Ingo Lütkebohle</author>
   <author email="fixed-term.christophe.bourquebedard@de.bosch.com">Christophe Bedard</author>
 

--- a/tracetools_analysis/setup.py
+++ b/tracetools_analysis/setup.py
@@ -32,7 +32,7 @@ setup(
         'fixed-term.christophe.bourquebedard@de.bosch.com, '
         'ingo.luetkebohle@de.bosch.com'
     ),
-    url='https://gitlab.com/ros-tracing/tracetools_analysis',
+    url='https://github.com/ros-tracing/tracetools_analysis',
     keywords=[],
     description='Tools for analysing trace data.',
     long_description=(


### PR DESCRIPTION
Part of https://gitlab.com/ros-tracing/tracetools_analysis/-/issues/55

And update other relevant links.

I commented out the GitHub CI badge for now.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>