### PR TITLE
Fix mypy errors

### DIFF
--- a/tracetools_analysis/tracetools_analysis/processor/__init__.py
+++ b/tracetools_analysis/tracetools_analysis/processor/__init__.py
@@ -41,9 +41,9 @@ class EventMetadata():
         event_name: str,
         timestamp: int,
         cpu_id: int,
-        procname: str = None,
-        pid: int = None,
-        tid: int = None,
+        procname: Optional[str] = None,
+        pid: Optional[int] = None,
+        tid: Optional[int] = None,
     ) -> None:
         """
         Create an EventMetadata.


### PR DESCRIPTION
This fixes mypy errors for a more recent version of mypy compared to the system version on Ubuntu 22.04. Therefore, while this isn't really necessary, I think it's still useful.

See also https://github.com/ros2/ros2_tracing/pull/28

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>