### PR TITLE
Update path to ros2_tracing in notebooks

### DIFF
--- a/tracetools_analysis/analysis/callback_duration.ipynb
+++ b/tracetools_analysis/analysis/callback_duration.ipynb
@@ -39,9 +39,9 @@
     "# There are two options:\n",
     "#   1. from source, assuming a workspace with:\n",
     "#       src/tracetools_analysis/\n",
-    "#       src/ros-tracing/ros2_tracing/tracetools_read/\n",
+    "#       src/ros2/ros2_tracing/tracetools_read/\n",
     "sys.path.insert(0, '../')\n",
-    "sys.path.insert(0, '../../../ros-tracing/ros2_tracing/tracetools_read/')\n",
+    "sys.path.insert(0, '../../../ros2/ros2_tracing/tracetools_read/')\n",
     "#   2. from Debian packages, setting the right ROS 2 distro:\n",
     "#ROS_DISTRO = 'rolling'\n",
     "#sys.path.insert(0, f'/opt/ros/{ROS_DISTRO}/lib/python3.8/site-packages')\n",
@@ -213,7 +213,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -227,7 +227,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/tracetools_analysis/analysis/lifecycle_states.ipynb
+++ b/tracetools_analysis/analysis/lifecycle_states.ipynb
@@ -32,9 +32,9 @@
     "# There are two options:\n",
     "#   1. from source, assuming a workspace with:\n",
     "#       src/tracetools_analysis/\n",
-    "#       src/ros-tracing/ros2_tracing/tracetools_read/\n",
+    "#       src/ros2/ros2_tracing/tracetools_read/\n",
     "sys.path.insert(0, '../')\n",
-    "sys.path.insert(0, '../../../ros-tracing/ros2_tracing/tracetools_read/')\n",
+    "sys.path.insert(0, '../../../ros2/ros2_tracing/tracetools_read/')\n",
     "#   2. from Debian packages, setting the right ROS 2 distro:\n",
     "#ROS_DISTRO = 'rolling'\n",
     "#sys.path.insert(0, f'/opt/ros/{ROS_DISTRO}/lib/python3.8/site-packages')\n",
@@ -145,7 +145,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -159,7 +159,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/tracetools_analysis/analysis/memory_usage.ipynb
+++ b/tracetools_analysis/analysis/memory_usage.ipynb
@@ -33,9 +33,9 @@
     "# There are two options:\n",
     "#   1. from source, assuming a workspace with:\n",
     "#       src/tracetools_analysis/\n",
-    "#       src/ros-tracing/ros2_tracing/tracetools_read/\n",
+    "#       src/ros2/ros2_tracing/tracetools_read/\n",
     "sys.path.insert(0, '../')\n",
-    "sys.path.insert(0, '../../../ros-tracing/ros2_tracing/tracetools_read/')\n",
+    "sys.path.insert(0, '../../../ros2/ros2_tracing/tracetools_read/')\n",
     "#   2. from Debian packages, setting the right ROS 2 distro:\n",
     "#ROS_DISTRO = 'rolling'\n",
     "#sys.path.insert(0, f'/opt/ros/{ROS_DISTRO}/lib/python3.8/site-packages')\n",
@@ -153,7 +153,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -167,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Since `ros2_tracing` is now at https://github.com/ros2/ros2_tracing