### PR TITLE
[Humble] Support traces with multiple callbacks for same pointer

### DIFF
--- a/tracetools_analysis/analysis/callback_duration.ipynb
+++ b/tracetools_analysis/analysis/callback_duration.ipynb
@@ -77,7 +77,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "data_util = Ros2DataModelUtil(handler.data)\n",
@@ -86,13 +88,17 @@
     "\n",
     "output_notebook()\n",
     "psize = 450\n",
+    "# If the trace contains more callbacks, add colours here\n",
+    "# or use: https://docs.bokeh.org/en/3.2.2/docs/reference/palettes.html\n",
     "colours = ['#29788E', '#DD4968', '#410967']"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "# Plot durations separately\n",
@@ -153,6 +159,7 @@
     "    )\n",
     "\n",
     "    colour_i += 1\n",
+    "    colour_i %= len(colours)\n",
     "    show(row(duration, hist))"
    ]
   },
@@ -197,6 +204,7 @@
     "        line_color=colours[colour_i],\n",
     "    )\n",
     "    colour_i += 1\n",
+    "    colour_i %= len(colours)\n",
     "    duration.legend.label_text_font_size = '11px'\n",
     "    duration.xaxis[0].formatter = DatetimeTickFormatter(seconds='%Ss')\n",
     "\n",
@@ -227,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some traces can contain more than 1 callback for the same callback object pointer. This can happen if we dynamically create and destroy subscriptions. Change the code to expect this. Just display the combined data and include information about all the subscriptions in the plot title (e.g., "/topic_a and /topic_b"). In this case, this means that we don't really know which part of the data belongs to which subscriptions. We could eventually look at the timestamps (e.g., when each subscription was created) and properly split the data, but this is a first step

Also, change how we display information in plot titles. Use newlines instead of commas to join the information, otherwise the title gets too wide and becomes unreadable:  
![bokeh_plot](https://github.com/ros-tracing/tracetools_analysis/assets/3717345/81ca89db-3970-4b20-a60c-a91f86a91363)