### PR TITLE
Use underscores in setup.cfg

### DIFF
--- a/tracetools_analysis/setup.cfg
+++ b/tracetools_analysis/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/tracetools_analysis
+script_dir=$base/lib/tracetools_analysis
 [install]
-install-scripts=$base/lib/tracetools_analysis
+install_scripts=$base/lib/tracetools_analysis


### PR DESCRIPTION
This fixes some warnings:

```
/home/christophe.bedard/.local/lib/python3.10/site-packages/setuptools/dist.py:771: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/home/christophe.bedard/.local/lib/python3.10/site-packages/setuptools/dist.py:771: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
--- stderr: tracetools_analysis                   
/home/christophe.bedard/.local/lib/python3.10/site-packages/setuptools/dist.py:771: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
```