### PR TITLE
Fix test_ros2trace_analysis package version

### DIFF
--- a/test_ros2trace_analysis/package.xml
+++ b/test_ros2trace_analysis/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>test_ros2trace_analysis</name>
-  <version>8.3.0</version>
+  <version>3.0.0</version>
   <description>Tests for the ros2trace_analysis package.</description>
   <maintainer email="bedard.christophe@gmail.com">Christophe Bedard</maintainer>
   <license>Apache 2.0</license>


### PR DESCRIPTION
Follow-up to #25. I missed updating this after I copy-pasted the boilerplate files.