### PR TITLE
Handle trace without callback objects

### DIFF
--- a/tracetools_analysis/test/tracetools_analysis/test_utils.py
+++ b/tracetools_analysis/test/tracetools_analysis/test_utils.py
@@ -16,6 +16,8 @@
 import unittest
 
 from tracetools_analysis import time_diff_to_str
+from tracetools_analysis.data_model.ros2 import Ros2DataModel
+from tracetools_analysis.utils.ros2 import Ros2DataModelUtil
 
 
 class TestUtils(unittest.TestCase):
@@ -31,3 +33,9 @@ class TestUtils(unittest.TestCase):
         self.assertEqual('1 m 10 s', time_diff_to_str(69.6969))
         self.assertEqual('6 m 10 s', time_diff_to_str(369.6969))
         self.assertEqual('2 m 0 s', time_diff_to_str(120.499999999))
+
+    def test_ros2_no_callbacks(self) -> None:
+        data_model = Ros2DataModel()
+        data_model.finalize()
+        util = Ros2DataModelUtil(data_model)
+        self.assertEqual({}, util.get_callback_symbols())

--- a/tracetools_analysis/tracetools_analysis/utils/ros2.py
+++ b/tracetools_analysis/tracetools_analysis/utils/ros2.py
@@ -117,6 +117,9 @@ class Ros2DataModelUtil(DataModelUtil):
         callback_instances = self.data.callback_instances
         callback_symbols = self.data.callback_symbols
 
+        if 'callback_object' not in callback_instances.columns:
+            return {}
+
         # Get a list of callback objects
         callback_objects = set(callback_instances['callback_object'])
         # Get their symbol


### PR DESCRIPTION
Otherwise, if there are no callbacks in the trace, `callback_instances['callback_object']` raises a `KeyError`.