### PR TITLE
Fix service_handle is unused

### DIFF
--- a/tracetools_analysis/tracetools_analysis/data_model/ros2.py
+++ b/tracetools_analysis/tracetools_analysis/data_model/ros2.py
@@ -159,7 +159,7 @@ class Ros2DataModel(DataModel):
         self, handle, timestamp, node_handle, rmw_handle, service_name
     ) -> None:
         self._services.append({
-            'service_handle': timestamp,
+            'service_handle': handle,
             'timestamp': timestamp,
             'node_handle': node_handle,
             'rmw_handle': rmw_handle,


### PR DESCRIPTION
As I tried to analyze client/service communication with the limited trace events available in ros2, I could not find the match between a service and its callback object. After investigating I stumbled upon this bug.

It would be nice if it could also be merged into humble :smile: